### PR TITLE
Various improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/config/client-info.yml

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,10 @@ IMAGE_VERSION=v1.0.0
 IMAGE_TAG=$(REGISTRY_NAME)/$(IMAGE_NAME):$(IMAGE_VERSION)
 
 # For now, only build linux/amd64 platform
-GOARCH?=amd64
+uname_m := $(shell uname -m)
+INCARCH.x86_64 := amd64
+INCARCH.aarch64 := arm64
+GOARCH += $(INCARCH.$(uname_m))
 BUILD_ENV=CGO_ENABLED=0 GOOS=linux GOARCH=$(GOARCH)
 BUILD_FLAGS="-extldflags \"-static\""
 
@@ -29,4 +32,3 @@ test:
 	go test -v ./test/...
 clean:
 	-rm -rf ./bin
-

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
-#!/bin/bash
-SOURCE_PATH=$(realpath "$(dirname "${BASH_SOURCE}")")
+#!/usr/bin/env bash
+SOURCE_PATH="$(cd "$(dirname "${BASH_SOURCE}")" && pwd -P)"
 
 echo "src path=""$SOURCE_PATH"
 cd "$SOURCE_PATH" || exit

--- a/deploy/kubernetes/v1.19/controller.yml
+++ b/deploy/kubernetes/v1.19/controller.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -23,7 +24,7 @@ rules:
     resources: ["persistentvolumes"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
   - apiGroups: [""]
-    resources: ["nodes"]
+    resources: ["nodes", "pods"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["csinodes"]
@@ -32,7 +33,7 @@ rules:
     resources: ["csinodeinfos"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
+    resources: ["volumeattachments", "volumeattachments/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
@@ -85,7 +86,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.0.0
           args:
             - --timeout=60s
             - --csi-address=$(ADDRESS)
@@ -103,7 +104,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-attacher:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.3.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)
@@ -120,7 +121,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/deploy/kubernetes/v1.19/csi-driver.yml
+++ b/deploy/kubernetes/v1.19/csi-driver.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: storage.k8s.io/v1
 kind: CSIDriver
 metadata:

--- a/deploy/kubernetes/v1.19/namespace.yml
+++ b/deploy/kubernetes/v1.19/namespace.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: Namespace
 metadata:

--- a/deploy/kubernetes/v1.19/node.yml
+++ b/deploy/kubernetes/v1.19/node.yml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -56,14 +57,14 @@ spec:
       labels:
         app: synology-csi-node
     spec:
-      serviceAccount: csi-node-sa
+      serviceAccountName: csi-node-sa
       hostNetwork: true
       containers:
         - name: csi-driver-registrar
           securityContext:
             privileged: true
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.3.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)                         # the csi socket path inside the pod

--- a/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
@@ -1,3 +1,4 @@
+---
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -64,7 +65,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-snapshotter:v3.0.3
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v4.2.1
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/deploy/kubernetes/v1.19/snapshotter/volume-snapshot-class.yml
+++ b/deploy/kubernetes/v1.19/snapshotter/volume-snapshot-class.yml
@@ -1,9 +1,10 @@
-apiVersion: snapshot.storage.k8s.io/v1beta1
+---
+apiVersion: snapshot.storage.k8s.io/v1
 kind: VolumeSnapshotClass
 metadata:
   name: synology-snapshotclass
   annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
+    storageclass.kubernetes.io/is-default-class: "true"
 driver: csi.san.synology.com
 deletionPolicy: Delete
 # parameters:

--- a/deploy/kubernetes/v1.19/storage-class.yml
+++ b/deploy/kubernetes/v1.19/storage-class.yml
@@ -11,16 +11,8 @@ provisioner: csi.san.synology.com
 #   dsm: '1.1.1.1'
 #   location: '/volume1'
 #   fsType: 'ext4'
+parameters:
+  fsType: ext4
+  location: /volume1
 reclaimPolicy: Retain
 allowVolumeExpansion: true
-
----
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
-metadata:
-  annotations:
-    storageclass.kubernetes.io/is-default-class: "false"
-  name: local-path
-provisioner: rancher.io/local-path
-reclaimPolicy: Delete
-volumeBindingMode: WaitForFirstConsumer

--- a/deploy/kubernetes/v1.19/storage-class.yml
+++ b/deploy/kubernetes/v1.19/storage-class.yml
@@ -1,9 +1,10 @@
+---
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
   name: synology-iscsi-storage
-  # annotations:
-  #   storageclass.kubernetes.io/is-default-class: "true"
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "true"
 provisioner: csi.san.synology.com
 # if all params are empty, synology CSI will choose an available location to create volume
 # parameters:
@@ -12,3 +13,14 @@ provisioner: csi.san.synology.com
 #   fsType: 'ext4'
 reclaimPolicy: Retain
 allowVolumeExpansion: true
+
+---
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  annotations:
+    storageclass.kubernetes.io/is-default-class: "false"
+  name: local-path
+provisioner: rancher.io/local-path
+reclaimPolicy: Delete
+volumeBindingMode: WaitForFirstConsumer

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,9 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
 plugin_name="csi.san.synology.com"
 deploy_k8s_version="v1.19"
 
-SCRIPT_PATH="$(realpath "$0")"
-SOURCE_PATH="$(realpath "$(dirname "${SCRIPT_PATH}")"/../)"
+SOURCE_PATH="$(cd "$(dirname "$0")/.." && pwd -P)"
 config_file="${SOURCE_PATH}/config/client-info.yml"
 plugin_dir="/var/lib/kubelet/plugins/$plugin_name"
 
@@ -19,10 +18,6 @@ csi_install(){
 
     kubectl create ns synology-csi
     kubectl create secret -n synology-csi generic client-info-secret --from-file="$config_file"
-
-    if [ ! -d "$plugin_dir" ]; then
-        mkdir -p $plugin_dir
-    fi
 
     kubectl apply -f "$SOURCE_PATH"/deploy/kubernetes/$deploy_k8s_version
 

--- a/scripts/uninstall.sh
+++ b/scripts/uninstall.sh
@@ -1,11 +1,10 @@
-#!/bin/bash
+#!/usr/bin/env bash
 echo "Uninstalling synology-csi pods ..."
 
 plugin_name="csi.san.synology.com"
 deploy_k8s_version="v1.19"
 
-SCRIPT_PATH="$(realpath "$0")"
-SOURCE_PATH="$(realpath "$(dirname "$SCRIPT_PATH")"/../)"
+SOURCE_PATH="$(cd "$(dirname "$0")/.." && pwd -P)"
 
 kubectl delete -f "$SOURCE_PATH"/deploy/kubernetes/$deploy_k8s_version/snapshotter --ignore-not-found
 kubectl delete -f "$SOURCE_PATH"/deploy/kubernetes/$deploy_k8s_version --ignore-not-found


### PR DESCRIPTION
+ Improves portability: no `realpath`, no hard coded bash path.
+ Updates third party container images for multi-arch clusters.
+ Updates resource manifests for K8s version 1.19+ (this should be more thoroughly tested with Git actions, though)