### PR TITLE
k8s: Update kubernetes deployment images

### DIFF
--- a/deploy/kubernetes/v1.19/controller.yml
+++ b/deploy/kubernetes/v1.19/controller.yml
@@ -32,7 +32,7 @@ rules:
     resources: ["csinodeinfos"]
     verbs: ["get", "list", "watch"]
   - apiGroups: ["storage.k8s.io"]
-    resources: ["volumeattachments"]
+    resources: ["volumeattachments", "volumeattachments/status"]
     verbs: ["get", "list", "watch", "update", "patch"]
   - apiGroups: ["storage.k8s.io"]
     resources: ["storageclasses"]
@@ -85,7 +85,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-provisioner:v1.6.0
+          image: k8s.gcr.io/sig-storage/csi-provisioner:v3.1.0
           args:
             - --timeout=60s
             - --csi-address=$(ADDRESS)
@@ -103,7 +103,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-attacher:v2.1.0
+          image: k8s.gcr.io/sig-storage/csi-attacher:v3.4.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)
@@ -120,7 +120,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-resizer:v0.5.0
+          image: k8s.gcr.io/sig-storage/csi-resizer:v1.3.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)

--- a/deploy/kubernetes/v1.19/csi-driver.yml
+++ b/deploy/kubernetes/v1.19/csi-driver.yml
@@ -5,5 +5,6 @@ metadata:
 spec:
   attachRequired: true # Indicates the driver requires an attach operation (TODO: ControllerPublishVolume should be implemented)
   podInfoOnMount: true
+  fsGroupPolicy: File
   volumeLifecycleModes:
     - Persistent

--- a/deploy/kubernetes/v1.19/node.yml
+++ b/deploy/kubernetes/v1.19/node.yml
@@ -63,7 +63,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: Always
-          image: quay.io/k8scsi/csi-node-driver-registrar:v1.2.0
+          image: k8s.gcr.io/sig-storage/csi-node-driver-registrar:v2.4.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)                         # the csi socket path inside the pod

--- a/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
@@ -64,7 +64,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: quay.io/k8scsi/csi-snapshotter:v3.0.3
+          image: k8s.gcr.io/sig-storage/csi-snapshotter:v5.0.0
           args:
             - --v=5
             - --csi-address=$(ADDRESS)


### PR DESCRIPTION
The kubernetes deployment images that are marked in the templates are
quite old (~2 years) and don't provide ARM images.  The image
publication has been moved to k8s.gcr.io/sig-storage in the interim
where ARM images are also available.

One of the updates also requires some additional role permissions for
the service user.

Additionally, this change updates the fsGroupPolicy for the CSIDriver as this
appears to function correctly and makes it more broadly useful.