### PR TITLE
add btrfs-progs package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ FROM alpine:latest
 LABEL maintainers="Synology Authors" \
       description="Synology CSI Plugin"
 
-RUN apk add --no-cache e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra blkid util-linux iproute2 bash
+RUN apk add --no-cache e2fsprogs e2fsprogs-extra xfsprogs xfsprogs-extra blkid util-linux iproute2 bash btrfs-progs
 
 # Create symbolic link for chroot.sh
 WORKDIR /


### PR DESCRIPTION
Currently, if we set `fsType: btrfs` in storageClass parameters, volume attachment failed with:
```
 E0206 01:20:30.741757 1375328 csi_attacher.go:340] kubernetes.io/csi: attacher.MountDevice failed: rpc error: code = Internal desc = format of disk "/dev/disk/by-path/ip-192.168.10.14:3260-iscsi-iqn.2000-01.com.synology:synology.pvc-ca911e21-70e6-460a-b56e-5412a8fb9a78-lun-1" failed: type:("btrfs") target:("/var/lib/kubelet/plugins/kubernetes.io/csi/pv/pvc-ca911e21-70e6-460a-b56e-5412a8fb9a78/globalmount") options:("rw,defaults") errcode:(executable file not found in $PATH) output:()
```

because the `csi-plugin` image missed the `mkfs.btrfs` executable