### PR TITLE
return extra lun info and allow create with direct_io_pattern

### DIFF
--- a/pkg/dsm/webapi/iscsi.go
+++ b/pkg/dsm/webapi/iscsi.go
@@ -14,15 +14,17 @@ import (
 )
 
 type LunInfo struct {
-	Name             string `json:"name"`
-	Uuid             string `json:"uuid"`
-	LunType          int    `json:"type"`
-	Location         string `json:"location"`
-	Size             uint64 `json:"size"`
-	Used             uint64 `json:"allocated_size"`
-	Status           string `json:"status"`
-	FlashcacheStatus string `json:"flashcache_status"`
-	IsActionLocked   bool   `json:"is_action_locked"`
+	Name             string         `json:"name"`
+	Uuid             string         `json:"uuid"`
+	LunType          int            `json:"type"`
+	Location         string         `json:"location"`
+	Size             uint64         `json:"size"`
+	Used             uint64         `json:"allocated_size"`
+	Status           string         `json:"status"`
+	FlashcacheStatus string         `json:"flashcache_status"`
+	IsActionLocked   bool           `json:"is_action_locked"`
+	DirectIOPattern  int            `json:"direct_io_pattern"`
+	DevAttribs       []LunDevAttrib `json:"dev_attribs"`
 }
 
 type MappedLun struct {
@@ -67,11 +69,12 @@ type LunDevAttrib struct {
 }
 
 type LunCreateSpec struct {
-	Name       string
-	Location   string
-	Size       int64
-	Type       string
-	DevAttribs []LunDevAttrib
+	Name            string
+	Location        string
+	Size            int64
+	Type            string
+	DirectIOPattern int
+	DevAttribs      []LunDevAttrib
 }
 
 type LunUpdateSpec struct {
@@ -165,6 +168,7 @@ func (dsm *DSM) LunCreate(spec LunCreateSpec) (string, error) {
 	params.Add("size", strconv.FormatInt(int64(spec.Size), 10))
 	params.Add("type", spec.Type)
 	params.Add("location", spec.Location)
+	params.Add("direct_io_pattern", strconv.FormatInt(int64(spec.DirectIOPattern), 10))
 
 	js, err := json.Marshal(spec.DevAttribs)
 	if err != nil {


### PR DESCRIPTION
Great project! I've started to use the `dsm/webapi` module for a project of my own - a CLI for Synology iSCSI storage which you can see [here](https://github.com/pfrybar/syno-iscsi).

Two features I would love to have for my CLI are:
1. Returning the `DevAttribs` along with the LUN info. My CLI allows creating a LUN with extra features like space reclamation and FUA/Sync cache. These are dev attributes which are already supported in the `LunCreateSpec`. However I can't display whether an existing LUN has these enabled or not since the dev attributes are not returned by the get/list methods.
2. Specify the I/O Policy during LUN creation. In the DSM webapp, you can see this option when editing a LUN, as shown in the first image below. I've tested it and this parameter can be passed along during LUN creation as well. By default, a LUN is created with a policy of `0` which maps to `Buffered I/O`. You can see this in the DSM `SYNO.Core.ISCSI.LUN` API response from the second image below. A value of `3` maps to the `Direct I/O` option.

This small PR adds both these features.

<img width="628" alt="Screenshot 2023-04-12 at 11 17 41" src="https://user-images.githubusercontent.com/1022924/231429013-dc230429-768d-48e2-b095-4584857da3e0.png">

<img width="507" alt="Screenshot 2023-04-12 at 11 24 11" src="https://user-images.githubusercontent.com/1022924/231431439-bb12f582-f225-4f66-868e-c1eba63d9e93.png">
