### PR TITLE
Update helm for custom kubelet path support

### DIFF
--- a/deploy/helm/templates/node.yaml
+++ b/deploy/helm/templates/node.yaml
@@ -147,15 +147,15 @@ spec:
             type: Directory
         - name: kubelet-dir
           hostPath:
-            path: /var/lib/kubelet
+            path: {{ .kubeletPath }}
             type: Directory
         - name: plugin-dir
           hostPath:
-            path: /var/lib/kubelet/plugins/csi.san.synology.com
+            path: {{ .kubeletPath }}/plugins/csi.san.synology.com
             type: DirectoryOrCreate
         - name: registration-dir
           hostPath:
-            path: /var/lib/kubelet/plugins_registry
+            path: {{ .kubeletPath }}/plugins_registry
             type: Directory
 {{- end }}
 {{- end }}

--- a/deploy/helm/templates/node.yaml
+++ b/deploy/helm/templates/node.yaml
@@ -82,7 +82,7 @@ spec:
                 fieldRef:
                   fieldPath: spec.nodeName
             - name: REGISTRATION_PATH
-              value: /var/lib/kubelet/plugins/csi.san.synology.com/csi.sock
+              value: {{ $.Values.node.kubeletPath }}/plugins/csi.san.synology.com/csi.sock
           {{- with .nodeDriverRegistrar }}
           image: {{ .image }}:{{ .tag }}
           imagePullPolicy: {{ .pullPolicy }}
@@ -122,7 +122,7 @@ spec:
             - name: host-root
               mountPath: /host
             - name: kubelet-dir
-              mountPath: /var/lib/kubelet
+              mountPath: {{ $.Values.node.kubeletPath }}
               mountPropagation: Bidirectional
             - name: plugin-dir
               mountPath: /csi

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -55,6 +55,9 @@ node:
   affinity: { }
   nodeSelector: { }
   tolerations: [ ]
+  # If your kubelet path is not standard, specify it here :
+  ## example for miocrok8s distrib : /var/snap/microk8s/common/var/lib/kubelet
+  kubeletPath: /var/lib/kubelet
 # Specifies affinity, nodeSelector and tolerations for the snapshotter StatefulSet
 snapshotter:
   affinity: { }


### PR DESCRIPTION
Helm modification to add support of custom path for kubelet. 

For example, microk8s uses /var/snap/microk8s/common/var/lib/kubelet as kubelet path, and it causes csi failure with default install parameters.
With new helm template, you can specify your own kubelet path from your host