### PR TITLE
Add pvc-namespace/pvc-name to lun descriptions

### DIFF
--- a/deploy/kubernetes/v1.19/controller.yml
+++ b/deploy/kubernetes/v1.19/controller.yml
@@ -96,6 +96,7 @@ spec:
             - --timeout=60s
             - --csi-address=$(ADDRESS)
             - --v=5
+            - --extra-create-metadata
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/deploy/kubernetes/v1.20/controller.yml
+++ b/deploy/kubernetes/v1.20/controller.yml
@@ -96,6 +96,7 @@ spec:
             - --timeout=60s
             - --csi-address=$(ADDRESS)
             - --v=5
+            - --extra-create-metadata
           env:
             - name: ADDRESS
               value: /var/lib/csi/sockets/pluginproxy/csi.sock

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -132,10 +132,20 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// used only in NodeStageVolume though VolumeContext
 	formatOptions := params["formatOptions"]
 
+	lunDescription := ""
+	if _, ok := params["csi.storage.k8s.io/pvc/name"]; ok {
+		// if the /pvc/name is present, the namespace is present too
+		// as these parameters are reserved by external-provisioner
+		pvcNamespace := params["csi.storage.k8s.io/pvc/namespace"]
+		pvcName := params["csi.storage.k8s.io/pvc/name"]
+		lunDescription = pvcNamespace + "/" + pvcName
+	}
+
 	spec := &models.CreateK8sVolumeSpec{
 		DsmIp:            params["dsm"],
 		K8sVolumeName:    volName,
 		LunName:          models.GenLunName(volName),
+		LunDescription:   lunDescription,
 		ShareName:        models.GenShareName(volName),
 		Location:         params["location"],
 		Size:             sizeInByte,

--- a/pkg/dsm/service/dsm.go
+++ b/pkg/dsm/service/dsm.go
@@ -168,7 +168,7 @@ func (service *DsmService) createMappingTarget(dsm *webapi.DSM, spec *models.Cre
 	}
 	targetSpec := webapi.TargetCreateSpec{
 		Name: spec.TargetName,
-		Iqn: genTargetIqn(),
+		Iqn:  genTargetIqn(),
 	}
 
 	log.Debugf("TargetCreate spec: %v", targetSpec)
@@ -224,10 +224,11 @@ func (service *DsmService) createVolumeByDsm(dsm *webapi.DSM, spec *models.Creat
 
 	// 3. Create LUN
 	lunSpec := webapi.LunCreateSpec{
-		Name:     spec.LunName,
-		Location: spec.Location,
-		Size:     spec.Size,
-		Type:     lunType,
+		Name:        spec.LunName,
+		Description: spec.LunDescription,
+		Location:    spec.Location,
+		Size:        spec.Size,
+		Type:        lunType,
 	}
 
 	log.Debugf("LunCreate spec: %v", lunSpec)

--- a/pkg/dsm/webapi/iscsi.go
+++ b/pkg/dsm/webapi/iscsi.go
@@ -67,11 +67,12 @@ type LunDevAttrib struct {
 }
 
 type LunCreateSpec struct {
-	Name       string
-	Location   string
-	Size       int64
-	Type       string
-	DevAttribs []LunDevAttrib
+	Name        string
+	Description string
+	Location    string
+	Size        int64
+	Type        string
+	DevAttribs  []LunDevAttrib
 }
 
 type LunUpdateSpec struct {
@@ -165,6 +166,7 @@ func (dsm *DSM) LunCreate(spec LunCreateSpec) (string, error) {
 	params.Add("size", strconv.FormatInt(int64(spec.Size), 10))
 	params.Add("type", spec.Type)
 	params.Add("location", spec.Location)
+	params.Add("description", spec.Description)
 
 	js, err := json.Marshal(spec.DevAttribs)
 	if err != nil {

--- a/pkg/models/dsm_req_spec.go
+++ b/pkg/models/dsm_req_spec.go
@@ -12,6 +12,7 @@ type CreateK8sVolumeSpec struct {
 	DsmIp            string
 	K8sVolumeName    string
 	LunName          string
+	LunDescription	 string
 	ShareName        string
 	Location         string
 	Size             int64


### PR DESCRIPTION
Closes #21 #39

According to [K8S Developer Documentation](https://kubernetes-csi.github.io/docs/external-provisioner.html) the external-provisioner starting with 1.6.0 can propagate PVC info to CreateVolume request. That info can be used to set LUN description like `pvc-namespace/pvc-name`:

With these changes by applying the next manifest

```
apiVersion: v1
kind: PersistentVolumeClaim
metadata:
  name: debug
  namespace: media
spec:
  resources:
    requests:
      storage: 1Gi
  volumeMode: Filesystem
  accessModes:
    - ReadWriteOnce
```

```
17:31:24 ❯ k get pvc debug
NAME    STATUS   VOLUME                                     CAPACITY   ACCESS MODES   STORAGECLASS         AGE
debug   Bound    pvc-81e319c3-3bbe-4ca9-a497-7b5ac3364a5b   5Gi        RWO            synology-iscsi-hdd   16s
```

I get the following LUN created:
<img width="1125" alt="image" src="https://github.com/SynologyOpenSource/synology-csi/assets/29075662/950e099d-4ebd-4263-8c56-0a9428a56f64">

After resizing, the description remains untouched:

<img width="1125" alt="image" src="https://github.com/SynologyOpenSource/synology-csi/assets/29075662/bce11215-56d7-4995-9e25-1b35c7085dc4">
