### PR TITLE
Enable volume stats and use statfs to report more accurate LUN usage

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/kubernetes-csi/csi-test/v4 v4.3.0
 	github.com/sirupsen/logrus v1.7.0
 	github.com/spf13/cobra v1.1.3
+	golang.org/x/sys v0.5.0
 	google.golang.org/grpc v1.34.0
 	google.golang.org/protobuf v1.25.0
 	gopkg.in/yaml.v2 v2.4.0

--- a/pkg/driver/driver.go
+++ b/pkg/driver/driver.go
@@ -79,8 +79,8 @@ func NewControllerAndNodeDriver(nodeID string, endpoint string, dsmService inter
 	d.addNodeServiceCapabilities([]csi.NodeServiceCapability_RPC_Type{
 		csi.NodeServiceCapability_RPC_STAGE_UNSTAGE_VOLUME,
 		csi.NodeServiceCapability_RPC_EXPAND_VOLUME,
+		csi.NodeServiceCapability_RPC_GET_VOLUME_STATS,
 		// csi.NodeServiceCapability_RPC_VOLUME_MOUNT_GROUP,
-		// csi.NodeServiceCapability_RPC_GET_VOLUME_STATS, //TODO
 	})
 
 	log.Infof("New driver created: name=%s, nodeID=%s, version=%s, endpoint=%s", d.name, d.nodeID, d.version, d.endpoint)


### PR DESCRIPTION
Addresses https://github.com/SynologyOpenSource/synology-csi/issues/51

Enables reporting the volume stats capability.

In the case iscsi LUNs use statfs to report accurate disk usage from the perspective of the client. Otherwise LUNs provisioned with discard appear immediately full and storage is never reclaimed.