### PR TITLE
Support for devAttribs

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,6 +167,7 @@ Create and apply StorageClasses with the properties you want.
     | *fsType*                                         | string | The formatting file system of the *PersistentVolumes* when you mount them on the pods. This parameter only works with iSCSI. For SMB, the fsType is always ‘cifs‘. | 'ext4'  | iSCSI               |
     | *protocol*                                       | string | The storage backend protocol. Enter ‘iscsi’ to create LUNs or ‘smb‘ to create shared folders on DSM.                                                               | 'iscsi' | iSCSI, SMB          |
     | *formatOptions*                                  | string | Additional options/arguments passed to `mkfs.*` command. See a linux manual that corresponds with your FS of choice.                                             | -       | iSCSI               |
+    | *devAttribs*                                     | string | Additional device attributes passed to LUN create API.                                                                                                             | -       | iSCSI               |
     | *csi.storage.k8s.io/node-stage-secret-name*      | string | The name of node-stage-secret. Required if DSM shared folder is accessed via SMB.                                                                                  | -       | SMB                 |
     | *csi.storage.k8s.io/node-stage-secret-namespace* | string | The namespace of node-stage-secret. Required if DSM shared folder is accessed via SMB.                                                                             | -       | SMB                 |
 
@@ -174,6 +175,7 @@ Create and apply StorageClasses with the properties you want.
 
     - If you leave the parameter *location* blank, the CSI driver will choose a volume on DSM with available storage to create the volumes.
     - All iSCSI volumes created by the CSI driver are Thin Provisioned LUNs on DSM. This will allow you to take snapshots of them.
+    - `devAttribs` is string of parameters separated with `,`. If the parameter name ends with `-`, the `-` sign is stripped and parameter is explicitly set to `Enabled: 0`.
 
 3. Apply the YAML files to the Kubernetes cluster.
 

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -132,6 +132,8 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	// used only in NodeStageVolume though VolumeContext
 	formatOptions := params["formatOptions"]
 
+	devAttribs := params["devAttribs"]
+
 	lunDescription := ""
 	if _, ok := params["csi.storage.k8s.io/pvc/name"]; ok {
 		// if the /pvc/name is present, the namespace is present too
@@ -156,6 +158,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		SourceSnapshotId: srcSnapshotId,
 		SourceVolumeId:   srcVolumeId,
 		Protocol:         protocol,
+		DevAttribs:       devAttribs,
 	}
 
 	// idempotency

--- a/pkg/dsm/service/dsm.go
+++ b/pkg/dsm/service/dsm.go
@@ -222,6 +222,22 @@ func (service *DsmService) createVolumeByDsm(dsm *webapi.DSM, spec *models.Creat
 			status.Errorf(codes.InvalidArgument, fmt.Sprintf("Unknown volume fs type: %s, location: %s", dsmVolInfo.FsType, spec.Location))
 	}
 
+	devAttribs := []webapi.LunDevAttrib{}
+	for _, attrib := range strings.Split(spec.DevAttribs,",") {
+		attrib = strings.TrimSpace(attrib)
+		if(len(attrib) < 1) { continue }
+		enabled := 1
+		if strings.HasSuffix(attrib, "-") {
+			attrib = strings.TrimSuffix(attrib,"-")
+			enabled = 0
+		}
+
+		devAttribs = append(devAttribs, webapi.LunDevAttrib{
+			DevAttrib: attrib,
+			Enable: enabled,
+		})
+	}
+
 	// 3. Create LUN
 	lunSpec := webapi.LunCreateSpec{
 		Name:        spec.LunName,
@@ -229,6 +245,7 @@ func (service *DsmService) createVolumeByDsm(dsm *webapi.DSM, spec *models.Creat
 		Location:    spec.Location,
 		Size:        spec.Size,
 		Type:        lunType,
+		DevAttribs:  devAttribs,
 	}
 
 	log.Debugf("LunCreate spec: %v", lunSpec)

--- a/pkg/models/dsm_req_spec.go
+++ b/pkg/models/dsm_req_spec.go
@@ -23,6 +23,7 @@ type CreateK8sVolumeSpec struct {
 	SourceSnapshotId string
 	SourceVolumeId   string
 	Protocol         string
+	DevAttribs       string
 }
 
 type K8sVolumeRespSpec struct {


### PR DESCRIPTION
Allow to set `DevAttribs` for LUN creation.

This allows user to set for example `emulate_tpu` and enable space reclamation.

Example storage class would look like this:

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
metadata:
  name: nas-iscsi
provisioner: csi.san.synology.com
parameters:
  dsm: 'my-nas'
  location: '/volume1'
  fsType: 'xfs'
  formatOptions: '-K'
  devAttribs: 'emulate_tpu'
reclaimPolicy: Retain
allowVolumeExpansion: true
```

I also added support to explicitly set flag to `0` (the strange syntax with `-` suffix is actually similar to how labels and annotations are set using kubectl) 