### PR TITLE
Switch helm readme to use helm-git until its published

### DIFF
--- a/deploy/helm/README.md
+++ b/deploy/helm/README.md
@@ -27,9 +27,9 @@ issues and to benefit from the advanced resource management features of Helm.
 
 ## Usage
 
-Once Helm has been set up correctly, add the repo as follows:
+Once Helm has been set up correctly (with [helm-git](https://github.com/aslafy-z/helm-git) plugin), add the repo as follows:
 
-    helm repo add synology-csi-chart https://christian-schlichtherle.github.io/synology-csi-chart
+    helm repo add synology-csi-chart 'git+https://github.com/SynologyOpenSource/synology-csi@deploy/helm?ref=main'er
 
 If you had already added this repo earlier, run `helm repo update` to retrieve the latest versions of the packages.
 You can then run `helm search repo synology-csi-chart` to see the charts.


### PR DESCRIPTION
Until helm chart is published to synology repo, update the readme to use git since it seems like https://github.com/christian-schlichtherle/synology-csi-chart/pull/13 isn't being updated anymore