### PR TITLE
[RFC] Add support for using PVC name as the Share name and ability to skip the share prefix

### DIFF
--- a/main.go
+++ b/main.go
@@ -55,14 +55,15 @@ var rootCmd = &cobra.Command{
 func driverStart() error {
 	log.Infof("CSI Options = {%s, %s, %s}", csiNodeID, csiEndpoint, csiClientInfoPath)
 
-	dsmService := service.NewDsmService()
-
 	// 1. Login DSMs by given ClientInfo
 	info, err := common.LoadConfig(csiClientInfoPath)
 	if err != nil {
 		log.Errorf("Failed to read config: %v", err)
 		return err
 	}
+
+
+	dsmService := service.NewDsmService(info.SkipLunPrefix, info.SkipSharePrefix)
 
 	for _, client := range info.Clients {
 		err := dsmService.AddDsm(client)

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -86,6 +86,12 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	volName, volCap := req.GetName(), req.GetVolumeCapabilities()
 	volContentSrc := req.GetVolumeContentSource()
 
+	// Check if use_pvc_name is true, and if so, use the pvc name as the volume name
+	usePvcName, _ := strconv.ParseBool(req.GetParameters()[models.CSIUsePVCName])
+	if usePvcName {
+		volName = req.GetParameters()[models.CSIPVCName]
+	}
+
 	var srcSnapshotId string = ""
 	var srcVolumeId string = ""
 	var multiSession bool = false
@@ -172,9 +178,9 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 	spec := &models.CreateK8sVolumeSpec{
 		DsmIp:            params["dsm"],
 		K8sVolumeName:    volName,
-		LunName:          models.GenLunName(volName),
+		LunName:          cs.dsmService.GenLunName(volName),
 		LunDescription:   lunDescription,
-		ShareName:        models.GenShareName(volName),
+		ShareName:        cs.dsmService.GenShareName(volName),
 		Location:         params["location"],
 		Size:             sizeInByte,
 		Type:             params["type"],

--- a/pkg/dsm/common/config.go
+++ b/pkg/dsm/common/config.go
@@ -19,7 +19,9 @@ type ClientInfo struct {
 }
 
 type SynoInfo struct {
-	Clients []ClientInfo `yaml:"clients"`
+	Clients         []ClientInfo `yaml:"clients"`
+	SkipLunPrefix   bool         `yaml:"skip_lun_prefix"`
+	SkipSharePrefix bool         `yaml:"skip_share_prefix"`
 }
 
 func LoadConfig(configPath string) (*SynoInfo, error) {

--- a/pkg/dsm/service/dsm.go
+++ b/pkg/dsm/service/dsm.go
@@ -7,27 +7,33 @@ package service
 import (
 	"errors"
 	"fmt"
-
-	"github.com/cenkalti/backoff/v4"
-	log "github.com/sirupsen/logrus"
-	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"strconv"
-	"time"
 	"strings"
+	"time"
+
 	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/common"
 	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/webapi"
 	"github.com/SynologyOpenSource/synology-csi/pkg/models"
 	"github.com/SynologyOpenSource/synology-csi/pkg/utils"
+	"github.com/cenkalti/backoff/v4"
+	log "github.com/sirupsen/logrus"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 type DsmService struct {
 	dsms map[string]*webapi.DSM
+
+	skipLunPrefix   bool
+	skipSharePrefix bool
 }
 
-func NewDsmService() *DsmService {
+func NewDsmService(skipLunPrefix bool, skipSharePrefix bool) *DsmService {
 	return &DsmService{
 		dsms: make(map[string]*webapi.DSM),
+
+		skipLunPrefix:   skipLunPrefix,
+		skipSharePrefix: skipSharePrefix,
 	}
 }
 
@@ -637,11 +643,30 @@ func (service *DsmService) GetVolume(volId string) *models.K8sVolumeRespSpec {
 	return nil
 }
 
+func (service *DsmService) GenLunName(volName string) string {
+	if service.skipLunPrefix {
+		return volName
+	}
+	return fmt.Sprintf("%s-%s", models.LunPrefix, volName)
+}
+
+func (service *DsmService) GenShareName(volName string) string {
+	log.Infof("GenShareName: %s, skipSharePrefix: %v", volName, service.skipSharePrefix)
+	shareName := volName
+	if !service.skipSharePrefix {
+		shareName = fmt.Sprintf("%s-%s", models.SharePrefix, volName)
+	}
+	if len(shareName) > models.MaxShareLen {
+		return shareName[:models.MaxShareLen]
+	}
+	return shareName
+}
+
 func (service *DsmService) GetVolumeByName(volName string) *models.K8sVolumeRespSpec {
 	volumes := service.ListVolumes()
 	for _, volume := range volumes {
-		if volume.Name == models.GenLunName(volName) ||
-			volume.Name == models.GenShareName(volName) {
+		if volume.Name == service.GenLunName(volName) ||
+			volume.Name == service.GenShareName(volName) {
 			return volume
 		}
 	}

--- a/pkg/interfaces/IDsmService.go
+++ b/pkg/interfaces/IDsmService.go
@@ -27,4 +27,6 @@ type IDsmService interface {
 	ListSnapshots(volId string) []*models.K8sSnapshotRespSpec
 	GetVolumeByName(volName string) *models.K8sVolumeRespSpec
 	GetSnapshotByName(snapshotName string) *models.K8sSnapshotRespSpec
+	GenLunName(volName string) string
+	GenShareName(volName string) string
 }

--- a/pkg/models/dsm.go
+++ b/pkg/models/dsm.go
@@ -2,10 +2,6 @@
 
 package models
 
-import (
-	"fmt"
-)
-
 const (
 	K8sCsiName       = "Kubernetes CSI"
 
@@ -33,16 +29,8 @@ const (
 	IqnPrefix               = "iqn.2000-01.com.synology:"
 	SharePrefix             = "k8s-csi"
 	ShareSnapshotDescPrefix = "(Do not change)"
+
+	// CSI parameter definitions
+	CSIPVCName    = "csi.storage.k8s.io/pvc/name"
+	CSIUsePVCName = "use_pvc_name"
 )
-
-func GenLunName(volName string) string {
-	return fmt.Sprintf("%s-%s", LunPrefix, volName)
-}
-
-func GenShareName(volName string) string {
-	shareName := fmt.Sprintf("%s-%s", SharePrefix, volName)
-	if len(shareName) > MaxShareLen {
-		return shareName[:MaxShareLen]
-	}
-	return shareName
-}


### PR DESCRIPTION
Hey all, wanted to get people's thoughts on a couple of changes I'd like to propose/ask-for.

The aim of these are to mainly to allow users to specify the name of the synology share name to be created or used.
I basically wanted to a) define the names of the shared, and b) use existing shares without having to rename them or use a separate CSI Samba plugin.

This PR/proposal is adding a couple of (off-by-default) options:
1) `skip_lun_prefix` and `skip_share_prefix` options in the `client-info` config.

Setting this to true will skip the prefix being added to the share name.

```yaml
skip_lun_prefix: false    # New parameter
skip_share_prefix: true   # New parameter
clients:
  - host: "10.0.0.10"
    username: "foo"
    password: "bar"
    https: false
    port: 5000
```

2) `use_pvc_name` option in the `StorageClass` parameters.

Setting this to true will use the CSI provided parameter `csi.storage.k8s.io/pvc/name` as the share name.

Ideally I would have liked to be able to provide a name for the volume directly, but from a quick Google and lurk in the CSI interface issues, it doesn't seem to be a way to pass PVC parameters to CSI plugins by design.

```yaml
apiVersion: storage.k8s.io/v1
kind: StorageClass
parameters:
  csi.storage.k8s.io/node-stage-secret-name: synology-csi-credentials
  csi.storage.k8s.io/node-stage-secret-namespace: system-synology-csi
  dsm: 10.0.0.10
  location: /volume1
  protocol: smb
  use_pvc_name: "true" # New parameter
provisioner: csi.san.synology.com
reclaimPolicy: Retain
volumeBindingMode: Immediate
allowVolumeExpansion: true
```

In combination, (1) and (2) allow you to use an existing share (as long as the share quota matches the requrested capacity).

---

I've only been using this plugin for a day or so, so I'm not sure if there is a reason why this shouldn't be supported or if there are additional things I might have missed in the code that require changing, as the lack of tests make it a bit hard to ensure I didn't break things.

I've deployed this in a local cluster and it seems to be working as expected with Samba shared both at creating new ones with the expected names, as well as reusing existing ones.

---

Now to the questions at hand:

a) Is this a feature you'd be interested in?
b) Would there be an alternative way to do this that you'd preffer to see for either (1) or (2)?
c) The code in this repo isn't really formatted, and in order to keep the PR more readable I've opted to not commit the fmt changes that go fmt is really insisting on.

Let me know I'd be happy to make any changes need to accomodate as I'd really not want to have to maintain a fork just for this. :)

Thank you for taking the time to build this plugin, it's really appreciated. 🙏 
Happy winter holidays and such! 🎄

Kind regards, @geoah