### PR TITLE
Normalize requested volume capacity to minimum required by Synology

### DIFF
--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -53,7 +53,8 @@ func getSizeByCapacityRange(capRange *csi.CapacityRange) (int64, error) {
 		return 0, status.Error(codes.InvalidArgument, "Invalid input: limitBytes is smaller than requiredBytes")
 	}
 	if minSize < utils.UNIT_GB {
-		return 0, status.Error(codes.InvalidArgument, "Invalid input: required bytes is smaller than 1G")
+		log.Debugf("Requested capacity [%d] is smaller than minimum 1G, using 1G for volume request", minSize)
+		return 1 * utils.UNIT_GB, nil
 	}
 
 	return int64(minSize), nil


### PR DESCRIPTION
If we request smaller than 1G then set the volume to 1G.

Fixes #78