### PR TITLE
deps: Add dependabot configuration to keep dependencies updated

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,19 @@
+version: 2
+
+updates:
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 2
+
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Using dependabot there  will be weekly automated PRs to keep dependencies updated.

This way we can reduce CVEs and ensure new features and such can be continuously updated.

See my fork for the result https://github.com/marcofranssen/synology-csi/pulls

> [!Note]
> I'm planning on adding automated CI workflows to raise our confidence to merge dependency updates. Some follow-up PRs will follow.

> [!Warning]
> Ensure to merge #115 as well so we have some automation dependency updates don't break compiling the binary.