### PR TITLE
deps: Bump Go from 1.21 to 1.25

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 Synology Inc.
 
 ############## Build stage ##############
-FROM golang:1.21.4-alpine as builder
+FROM golang:1.25.5-alpine3.23 AS builder
 LABEL stage=synobuilder
 
 RUN apk add --no-cache alpine-sdk
@@ -20,7 +20,7 @@ RUN env GOARCH=$(echo "$TARGETPLATFORM" | cut -f2 -d/) \
         make
 
 ############## Final stage ##############
-FROM alpine:latest
+FROM alpine:3.23.2
 LABEL maintainers="Synology Authors" \
       description="Synology CSI Plugin"
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SynologyOpenSource/synology-csi
 
-go 1.21
+go 1.25
 
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1


### PR DESCRIPTION
This PR builds on top of #115

If we can merge #115 first we have an automated workflow to proof the binary still correctly compiles using Go 1.25
