### PR TITLE
Add registry reference to avoid CRI-O enforced short-name-mode issue

### DIFF
--- a/deploy/helm/templates/test.yaml
+++ b/deploy/helm/templates/test.yaml
@@ -37,7 +37,7 @@ spec:
       containers:
         - name: touch
           command: [ "/bin/sh", "-c", "echo 'Hello world!' >/data/file" ]
-          image: busybox
+          image: docker.io/busybox
           volumeMounts:
             - mountPath: /data
               name: data

--- a/deploy/helm/values.yaml
+++ b/deploy/helm/values.yaml
@@ -32,7 +32,7 @@ images:
     pullPolicy: IfNotPresent
     tag: v2.6.3
   plugin:
-    image: synology/synology-csi
+    image: docker.io/synology/synology-csi
     pullPolicy: IfNotPresent
     # Defaults to {{ $.Chart.AppVersion }} if empty or not present:
     tag: ""

--- a/deploy/kubernetes/v1.19/controller.yml
+++ b/deploy/kubernetes/v1.19/controller.yml
@@ -144,7 +144,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.1
+          image: docker.io/synology/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.19/node.yml
+++ b/deploy/kubernetes/v1.19/node.yml
@@ -86,7 +86,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: IfNotPresent
-          image: synology/synology-csi:v1.2.1
+          image: docker.io/synology/synology-csi:v1.2.1
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.19/snapshotter/snapshotter.yaml
@@ -81,7 +81,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.1
+          image: docker.io/synology/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/controller.yml
+++ b/deploy/kubernetes/v1.20/controller.yml
@@ -144,7 +144,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.1
+          image: docker.io/synology/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/node.yml
+++ b/deploy/kubernetes/v1.20/node.yml
@@ -86,7 +86,7 @@ spec:
           securityContext:
             privileged: true
           imagePullPolicy: IfNotPresent
-          image: synology/synology-csi:v1.2.1
+          image: docker.io/synology/synology-csi:v1.2.1
           args:
             - --nodeid=$(KUBE_NODE_NAME)
             - --endpoint=$(CSI_ENDPOINT)

--- a/deploy/kubernetes/v1.20/snapshotter/snapshotter.yaml
+++ b/deploy/kubernetes/v1.20/snapshotter/snapshotter.yaml
@@ -81,7 +81,7 @@ spec:
             capabilities:
               add: ["SYS_ADMIN"]
             allowPrivilegeEscalation: true
-          image: synology/synology-csi:v1.2.1
+          image: docker.io/synology/synology-csi:v1.2.1
           args:
             - --nodeid=NotUsed
             - --endpoint=$(CSI_ENDPOINT)


### PR DESCRIPTION
Add registry reference to manifest files where it is missing to avoid in CRI-O 1.34 introduced security change `short_name_mode = "enforcing"`.

CRI-O Upstream change [HERE](https://github.com/cri-o/cri-o/commit/a8b550ad04ddf525cd6b8c026adf1d0030ebaab4).

Closes: #128