### PR TITLE
Add iSCSI target interface binding support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ COPY main.go .
 COPY pkg ./pkg
 RUN env GOARCH=$(echo "$TARGETPLATFORM" | cut -f2 -d/) \
         GOARM=$(echo "$TARGETPLATFORM" | cut -f3 -d/ | cut -c2-) \
-        make
+        make bin/synology-csi-driver
 
 ############## Final stage ##############
 FROM alpine:latest

--- a/README.md
+++ b/README.md
@@ -119,6 +119,7 @@ Create and apply StorageClasses with the properties you want.
       fsType: 'btrfs'
       dsm: '192.168.1.1'
       location: '/volume1'
+      iscsiInterfaceNames: 'bond0'
       formatOptions: '--nodiscard'
     reclaimPolicy: Retain
     allowVolumeExpansion: true
@@ -184,6 +185,7 @@ Create and apply StorageClasses with the properties you want.
     | *location*                                       | string | The location (/volume1, /volume2, ...) on DSM where the LUN for *PersistentVolume* will be created                                                                 | -       | iSCSI, SMB, NFS     |
     | *fsType*                                         | string | The formatting file system of the *PersistentVolumes* when you mount them on the pods. This parameter only works with iSCSI. For SMB, the fsType is always ‘cifs‘. | 'ext4'  | iSCSI               |
     | *protocol*                                       | string | The storage backend protocol. Enter ‘iscsi’ to create LUNs, or ‘smb‘ or 'nfs' to create shared folders on DSM.                                                     | 'iscsi' | iSCSI, SMB, NFS     |
+    | *iscsiInterfaceNames*                            | string | A comma-separated list of DSM iSCSI interface names to bind to each created iSCSI target, for example `bond0` or `eth0,eth1`.                                     | -       | iSCSI               |
     | *formatOptions*                                  | string | Additional options/arguments passed to `mkfs.*` command. See a linux manual that corresponds with your FS of choice.                                               | -       | iSCSI               |
     | *enableSpaceReclamation*                         | string | Enables space reclamation for Thin Provisioned Btrfs LUNs to improve storage efficiency. May impact performance and space display.                                 | 'false' | iSCSI               |
     | *enableFuaSyncCache*                             | string | Enables FUA and Sync Cache SCSI commands for LUNs.                                                                                                                 | 'false' | iSCSI               |
@@ -195,6 +197,7 @@ Create and apply StorageClasses with the properties you want.
 
     - If you leave the parameter *location* blank, the CSI driver will choose a volume on DSM with available storage to create the volumes.
     - All iSCSI volumes created by the CSI driver are Thin Provisioned LUNs on DSM. This will allow you to take snapshots of them.
+    - The value of *iscsiInterfaceNames* must match the DSM interface names used by SAN Manager and the DSM API, such as `bond0` or `eth0`.
 
 3. Apply the YAML files to the Kubernetes cluster.
 
@@ -256,4 +259,3 @@ If you want to use images you built locally for installation, edit all files und
 ### Uninstallation
 If you are no longer using the CSI driver, make sure that no other resources in your Kubernetes cluster are using storage managed by Synology CSI driver before uninstalling it.
 - `./scripts/uninstall.sh`
-

--- a/deploy/example/storageclass-iscsi.yaml
+++ b/deploy/example/storageclass-iscsi.yaml
@@ -1,0 +1,13 @@
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: synostorage
+provisioner: csi.san.synology.com
+parameters:
+  dsm: "192.168.1.1"
+  location: "/volume1"
+  fsType: "btrfs"
+  iscsiInterfaceNames: "bond0"
+  formatOptions: "--nodiscard"
+reclaimPolicy: Retain
+allowVolumeExpansion: true

--- a/pkg/driver/controllerserver.go
+++ b/pkg/driver/controllerserver.go
@@ -96,6 +96,27 @@ func parseDevAttribs(params map[string]string) (map[string]bool, error) {
 	return attribFlags, nil
 }
 
+func parseIscsiInterfaceNames(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+
+	names := []string{}
+	for _, name := range strings.Split(raw, ",") {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		names = append(names, name)
+	}
+
+	if len(names) == 0 {
+		return nil
+	}
+
+	return names
+}
+
 func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVolumeRequest) (*csi.CreateVolumeResponse, error) {
 	sizeInByte, err := getSizeByCapacityRange(req.GetCapacityRange())
 	volName, volCap := req.GetName(), req.GetVolumeCapabilities()
@@ -209,6 +230,7 @@ func (cs *controllerServer) CreateVolume(ctx context.Context, req *csi.CreateVol
 		Protocol:         protocol,
 		NfsVersion:       nfsVer,
 		DevAttribs:       devAttribs,
+		IscsiInterfaceNames: parseIscsiInterfaceNames(params["iscsiInterfaceNames"]),
 	}
 
 	// idempotency

--- a/pkg/dsm/service/dsm.go
+++ b/pkg/dsm/service/dsm.go
@@ -189,6 +189,15 @@ func (service *DsmService) createMappingTarget(dsm *webapi.DSM, spec *models.Cre
 		targetId = strconv.Itoa(targetInfo.TargetId);
 	}
 
+	if len(spec.IscsiInterfaceNames) > 0 {
+		if err := dsm.TargetResetNetworkPortals(targetId); err != nil {
+			return webapi.TargetInfo{}, status.Errorf(codes.Internal, fmt.Sprintf("Failed to reset target [%s] network portals, err: %v", spec.TargetName, err))
+		}
+		if err := dsm.TargetAddNetworkPortals(targetId, spec.IscsiInterfaceNames); err != nil {
+			return webapi.TargetInfo{}, status.Errorf(codes.Internal, fmt.Sprintf("Failed to add target [%s] network portals %v, err: %v", spec.TargetName, spec.IscsiInterfaceNames, err))
+		}
+	}
+
 	if spec.MultipleSession == true {
 		if err := dsm.TargetSet(targetId, 0); err != nil {
 			return webapi.TargetInfo{}, status.Errorf(codes.Internal, fmt.Sprintf("Failed to set target [%s] max session, err: %v", spec.TargetName, err))
@@ -197,6 +206,11 @@ func (service *DsmService) createMappingTarget(dsm *webapi.DSM, spec *models.Cre
 
 	if err := dsm.LunMapTarget([]string{targetId}, lunUuid); err != nil {
 		return webapi.TargetInfo{}, status.Errorf(codes.Internal, fmt.Sprintf("Failed to map target [%s] to lun [%s], err: %v", spec.TargetName, lunUuid, err))
+	}
+
+	targetInfo, err = dsm.TargetGet(targetSpec.Name)
+	if err != nil {
+		return webapi.TargetInfo{}, status.Errorf(codes.Internal, fmt.Sprintf("Failed to refresh target with spec: %v, err: %v", targetSpec, err))
 	}
 
 	return targetInfo, nil

--- a/pkg/dsm/webapi/iscsi.go
+++ b/pkg/dsm/webapi/iscsi.go
@@ -92,6 +92,10 @@ type TargetCreateSpec struct {
 	Iqn  string
 }
 
+type TargetNetworkPortal struct {
+	InterfaceName string `json:"interface_name"`
+}
+
 type SnapshotCreateSpec struct {
 	Name        string
 	LunUuid     string
@@ -340,6 +344,54 @@ func (dsm *DSM) TargetCreate(spec TargetCreateSpec) (string, error) {
 	}
 
 	return strconv.Itoa(trgResp.TargetId), nil
+}
+
+func (dsm *DSM) TargetAddNetworkPortals(targetId string, interfaceNames []string) error {
+	if len(interfaceNames) == 0 {
+		return nil
+	}
+
+	networkPortals := make([]TargetNetworkPortal, 0, len(interfaceNames))
+	for _, interfaceName := range interfaceNames {
+		networkPortals = append(networkPortals, TargetNetworkPortal{InterfaceName: interfaceName})
+	}
+
+	compoundReq := []map[string]interface{}{
+		{
+			"api":             "SYNO.Core.ISCSI.Target",
+			"method":          "network_portals_add",
+			"version":         1,
+			"target_id":       targetId,
+			"network_portals": networkPortals,
+		},
+	}
+
+	compoundJSON, err := json.Marshal(compoundReq)
+	if err != nil {
+		return err
+	}
+
+	params := url.Values{}
+	params.Add("api", "SYNO.Entry.Request")
+	params.Add("method", "request")
+	params.Add("version", "1")
+	params.Add("stop_when_error", "true")
+	params.Add("mode", strconv.Quote("sequential"))
+	params.Add("compound", string(compoundJSON))
+
+	resp, err := dsm.sendRequest("", &struct{}{}, params, "webapi/entry.cgi")
+	if err != nil {
+		return errCodeMapping(resp.ErrorCode, err)
+	}
+
+	return nil
+}
+
+func (dsm *DSM) TargetResetNetworkPortals(targetId string) error {
+	// DSM treats "all" as the default placeholder portal set. Resetting to it
+	// lets us reconcile existing concrete portal bindings before applying the
+	// requested interfaces.
+	return dsm.TargetAddNetworkPortals(targetId, []string{"all"})
 }
 
 func (dsm *DSM) LunMapTarget(targetIds []string, lunUuid string) error {

--- a/pkg/models/dsm_req_spec.go
+++ b/pkg/models/dsm_req_spec.go
@@ -25,6 +25,7 @@ type CreateK8sVolumeSpec struct {
 	Protocol         string
 	NfsVersion       string
 	DevAttribs       map[string]bool
+	IscsiInterfaceNames []string
 }
 
 type K8sVolumeRespSpec struct {


### PR DESCRIPTION
## Summary

Adds support for binding created iSCSI targets to specific DSM interfaces via a new StorageClass parameter: `iscsiInterfaceNames`.

## Changes

- parse `iscsiInterfaceNames` in the controller
- pass interface names through the DSM volume spec
- add DSM target network portal helpers
- reset and reapply target portals during provisioning to avoid stale concrete portal assignments
- document the new parameter in `README.md`
- add an example iSCSI StorageClass
- fix Docker image build to compile only `bin/synology-csi-driver`

## Example

```yaml
parameters:
  dsm: "192.168.1.1"
  fsType: ext4
  location: /volume1
  iscsiInterfaceNames: bond0
```
