### PR TITLE
fix: Error 18990403: Bad description when creating PVC in digits-only namespace

### DIFF
--- a/pkg/dsm/webapi/iscsi.go
+++ b/pkg/dsm/webapi/iscsi.go
@@ -169,7 +169,7 @@ func (dsm *DSM) LunCreate(spec LunCreateSpec) (string, error) {
 	params.Add("size", strconv.FormatInt(int64(spec.Size), 10))
 	params.Add("type", spec.Type)
 	params.Add("location", spec.Location)
-	params.Add("description", spec.Description)
+	params.Add("description", strconv.Quote(spec.Description))
 
 	js, err := json.Marshal(spec.DevAttribs)
 	if err != nil {

--- a/pkg/dsm/webapi/iscsi.go
+++ b/pkg/dsm/webapi/iscsi.go
@@ -110,6 +110,8 @@ func errCodeMapping(errCode int, oriErr error) error {
 	switch errCode {
 	case 18990002: // Out of free space
 		return utils.OutOfFreeSpaceError("")
+	case 18990403:
+		return utils.BadDescriptionError("")
 	case 18990531: // No such LUN
 		return utils.NoSuchLunError("")
 	case 18990538: // Duplicated LUN name

--- a/pkg/utils/error.go
+++ b/pkg/utils/error.go
@@ -21,6 +21,7 @@ type IscsiDefaultError struct {
 type NoSuchShareError string
 type ShareReachMaxCountError string
 type ShareSystemBusyError string
+type BadDescriptionError string
 type ShareDefaultError struct {
 	ErrCode int
 }
@@ -33,6 +34,9 @@ func (_ AlreadyExistError) Error() string {
 }
 func (_ BadParametersError) Error() string {
 	return "Invalid input value"
+}
+func (_ BadDescriptionError) Error() string {
+	return "Bad description"
 }
 
 // ISCSI errors


### PR DESCRIPTION
* Added a new error type `BadDescriptionError` to `pkg/utils/error.go` to represent invalid LUN descriptions.
* Updated `errCodeMapping` in `pkg/dsm/webapi/iscsi.go` to map error code `18990403` to the new `BadDescriptionError`.
* Modified `LunCreate` in `pkg/dsm/webapi/iscsi.go` to quote the `description` parameter to avoid it being treated as a number.

resolves #134