### PR TITLE
fix: Docker build fails with missing synocli directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 Synology Inc.
 
 ############## Build stage ##############
-FROM golang:1.26.2-alpine AS builder
+FROM golang:1.26.2-alpine3.23 AS builder
 LABEL stage=synobuilder
 
 RUN apk add --no-cache alpine-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 Synology Inc.
 
 ############## Build stage ##############
-FROM golang:1.21.4-alpine AS builder
+FROM golang:1.26.2-alpine AS builder
 LABEL stage=synobuilder
 
 RUN apk add --no-cache alpine-sdk
@@ -21,7 +21,7 @@ RUN env GOARCH=$(echo "$TARGETPLATFORM" | cut -f2 -d/) \
         make
 
 ############## Final stage ##############
-FROM alpine:latest
+FROM alpine:3.23.4
 LABEL maintainers="Synology Authors" \
       description="Synology CSI Plugin"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # Copyright 2021 Synology Inc.
 
 ############## Build stage ##############
-FROM golang:1.21.4-alpine as builder
+FROM golang:1.21.4-alpine AS builder
 LABEL stage=synobuilder
 
 RUN apk add --no-cache alpine-sdk

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ARG TARGETPLATFORM
 
 COPY main.go .
 COPY pkg ./pkg
+COPY synocli ./synocli
 RUN env GOARCH=$(echo "$TARGETPLATFORM" | cut -f2 -d/) \
         GOARM=$(echo "$TARGETPLATFORM" | cut -f3 -d/ | cut -c2-) \
         make

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/SynologyOpenSource/synology-csi
 
-go 1.21
+go 1.26
 
 require (
 	github.com/antonfisher/nested-logrus-formatter v1.3.1


### PR DESCRIPTION
* Upgraded the Go builder image from `golang:1.21.4-alpine` to `golang:1.26.2-alpine.
* Pinned the final runtime image from `alpine:latest` to `alpine:3.23.4` to improve stability/traceability.
* Added the missing `synocli` directory to the build context.

resolves #136 