### PR TITLE
fix(docker): copy synocli source into build context

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,7 @@ ARG TARGETPLATFORM
 
 COPY main.go .
 COPY pkg ./pkg
+COPY synocli ./synocli
 RUN env GOARCH=$(echo "$TARGETPLATFORM" | cut -f2 -d/) \
         GOARM=$(echo "$TARGETPLATFORM" | cut -f3 -d/ | cut -c2-) \
         make


### PR DESCRIPTION
## Summary

`docker build` currently fails on an unmodified checkout of `main`. The
build stage's `make` target compiles both `bin/synology-csi-driver` and
`bin/synocli` (since `build: bin/synology-csi-driver bin/synocli` was
introduced in the CI-workflow commit), but the Dockerfile only ever
`COPY`s `main.go` and `pkg/` into the builder image - `synocli/` was
never added to the `COPY` list, so the in-container `make` fails:

```
Compiling bin/synocli…
stat /go/src/synok8scsiplugin/synocli: directory not found
make: *** [Makefile:42: bin/synocli] Error 1
```

This is why it hasn't been caught by CI: `.github/workflows/ci.yaml`
only runs `make build` directly on the runner (where `synocli/` is
already present in the full checkout) and never invokes `docker build`,
so the two build paths diverged silently. Reproducible on a clean
checkout of `main` with just `docker build -t test .`.

## Fix

Add the missing `COPY synocli ./synocli` alongside the existing
`COPY main.go .` / `COPY pkg ./pkg` lines.

## Test plan

- [x] `docker build -t synology-csi:test .` fails on unmodified `main` with the error above
- [x] Same build succeeds with this one-line change, producing a working image (arm64), which I've since run in a live cluster