### PR TITLE
fix(nfs): retry transient DSM busy errors on NFS share privilege calls

### DIFF
--- a/pkg/driver/nodeserver.go
+++ b/pkg/driver/nodeserver.go
@@ -18,6 +18,7 @@ package driver
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -415,7 +416,24 @@ func (ns *nodeServer) setNFSVolumePrivilege(sourcePath string, hostnames []strin
 		})
 	}
 
-	err = dsm.ShareNfsPrivilegeSave(priv)
+	privilegeBackoff := backoff.NewExponentialBackOff()
+	privilegeBackoff.InitialInterval = 2 * time.Second
+	privilegeBackoff.Multiplier = 2
+	privilegeBackoff.RandomizationFactor = 0.1
+	privilegeBackoff.MaxElapsedTime = 30 * time.Second
+
+	privilegeNotify := func(err error, duration time.Duration) {
+		log.Infof("Share NFS privilege system busy, retrying in %3.2f seconds.....", float64(duration.Seconds()))
+	}
+
+	err = backoff.RetryNotify(func() error {
+		saveErr := dsm.ShareNfsPrivilegeSave(priv)
+		if saveErr != nil && !errors.Is(saveErr, utils.ShareSystemBusyError("")) {
+			return backoff.Permanent(saveErr)
+		}
+		return saveErr
+	}, privilegeBackoff, privilegeNotify)
+
 	if err != nil {
 		log.Printf("Failed to save share NFS privilege. Priv:%v. %v", priv, err)
 		return err

--- a/pkg/dsm/service/share_volume.go
+++ b/pkg/dsm/service/share_volume.go
@@ -16,6 +16,7 @@ import (
 	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/webapi"
 	"github.com/SynologyOpenSource/synology-csi/pkg/models"
 	"github.com/SynologyOpenSource/synology-csi/pkg/utils"
+	"github.com/cenkalti/backoff/v4"
 )
 
 func GMTToUnixSecond(timeStr string) (int64) {
@@ -205,9 +206,9 @@ func (service *DsmService) listSMBorNFSVolumes(dsmIp string) (infos []*models.K8
 				continue
 			}
 			// if share has set nfs rule, deal it as NFS
-			sharePrivilege, err := dsm.ShareNfsPrivilegeLoad(share.Name)
+			sharePrivilege, err := loadShareNfsPrivilegeWithRetry(dsm, share.Name)
 			if err != nil {
-				log.Errorf("[%s] Failed to load share nfs privilege: %v", dsm.Ip, err)
+				log.Errorf("[%s] Failed to load share nfs privilege after retries: %v", dsm.Ip, err)
 				continue
 			}
 			if len(sharePrivilege.Rule) > 0 {
@@ -219,6 +220,30 @@ func (service *DsmService) listSMBorNFSVolumes(dsmIp string) (infos []*models.K8
 	}
 
 	return infos
+}
+
+func loadShareNfsPrivilegeWithRetry(dsm *webapi.DSM, shareName string) (webapi.SharePrivilege, error) {
+	privilegeBackoff := backoff.NewExponentialBackOff()
+	privilegeBackoff.InitialInterval = 1 * time.Second
+	privilegeBackoff.Multiplier = 2
+	privilegeBackoff.RandomizationFactor = 0.1
+	privilegeBackoff.MaxElapsedTime = 10 * time.Second
+
+	notify := func(err error, duration time.Duration) {
+		log.Infof("[%s] Share NFS privilege system busy while loading [%s], retrying in %3.2f seconds.....", dsm.Ip, shareName, float64(duration.Seconds()))
+	}
+
+	var sharePrivilege webapi.SharePrivilege
+	err := backoff.RetryNotify(func() error {
+		var loadErr error
+		sharePrivilege, loadErr = dsm.ShareNfsPrivilegeLoad(shareName)
+		if loadErr != nil && !errors.Is(loadErr, utils.ShareSystemBusyError("")) {
+			return backoff.Permanent(loadErr)
+		}
+		return loadErr
+	}, privilegeBackoff, notify)
+
+	return sharePrivilege, err
 }
 
 func (service *DsmService) listSMBorNFSSnapshotsByDsm(dsm *webapi.DSM) (infos []*models.K8sSnapshotRespSpec) {

--- a/pkg/dsm/webapi/share.go
+++ b/pkg/dsm/webapi/share.go
@@ -108,6 +108,14 @@ func shareErrCodeMapping(errCode int, oriErr error) error {
 	return oriErr
 }
 
+func nfsPrivilegeErrCodeMapping(errCode int, oriErr error) error {
+	switch errCode {
+	case 2370: // NFS privilege subsystem temporarily busy (e.g. under concurrent share creation)
+		return utils.ShareSystemBusyError("")
+	}
+	return oriErr
+}
+
 // ----------------------- Share APIs -----------------------
 func (dsm *DSM) ShareGet(shareName string) (ShareInfo, error) {
 	params := url.Values{}
@@ -413,12 +421,9 @@ func (dsm *DSM) ShareNfsPrivilegeSave(privilege SharePrivilege) error {
 	}
 	params.Add("rule", string(js))
 
-	_, err = dsm.sendRequest("", &struct{}{}, params, "webapi/entry.cgi")
-	if err != nil {
-		return err
-	}
+	resp, err := dsm.sendRequest("", &struct{}{}, params, "webapi/entry.cgi")
 
-	return nil
+	return nfsPrivilegeErrCodeMapping(resp.ErrorCode, err)
 }
 
 func (dsm *DSM) ShareNfsPrivilegeLoad(shareName string) (SharePrivilege, error) {
@@ -429,9 +434,9 @@ func (dsm *DSM) ShareNfsPrivilegeLoad(shareName string) (SharePrivilege, error) 
 	params.Add("version", "1")
 
 	info := SharePrivilege{}
-	_, err := dsm.sendRequest("", &info, params, "webapi/entry.cgi")
+	resp, err := dsm.sendRequest("", &info, params, "webapi/entry.cgi")
 	if err != nil {
-		return SharePrivilege{}, err
+		return SharePrivilege{}, nfsPrivilegeErrCodeMapping(resp.ErrorCode, err)
 	}
 
 	return info, nil


### PR DESCRIPTION
## Problem

Closes #139

Under concurrent PVC creation (multiple Helm-chart PVCs, or a Kasten
K10 restore creating several volumes at once), DSM's NFS
`SharePrivilege` API can return a transient "system busy" response
(observed as DSM error `2370`). The driver had no classification for
that API's error codes and no retry around it:

- During `NodeStageVolume`, a single busy hit on `ShareNfsPrivilegeSave`
  failed the call outright, surfacing as a misleading
  `mount.nfs: ... No such file or directory` on the node, even though
  the share itself existed - it just never got its NFS export rule
  written.
- During volume listing (`ListVolumes` / the `CreateVolume` idempotency
  check), the same busy condition on `ShareNfsPrivilegeLoad` caused a
  share to be silently dropped from the result set for that call, as
  if it didn't exist.

Neither case corrupts state - `CreateVolume` never sets NFS privileges
itself (that happens per-node in `NodeStageVolume`, since the export
rule is built from the current cluster node IP list), so there's
nothing to roll back. The fix is to retry the transient condition
instead of failing or hiding the share on the first hit.

## Fix

- **`pkg/dsm/webapi/share.go`**: add `nfsPrivilegeErrCodeMapping()`,
  mirroring the existing `shareErrCodeMapping` / `errCodeMapping` /
  `sanErrCodeMapping` per-API-family convention already used elsewhere
  in this package, mapping DSM error `2370` to the existing
  `utils.ShareSystemBusyError`. Applied to `ShareNfsPrivilegeSave` and
  `ShareNfsPrivilegeLoad`, which previously returned the raw,
  unclassified error.
- **`pkg/driver/nodeserver.go`**: wrap `ShareNfsPrivilegeSave` in
  `setNFSVolumePrivilege` with a bounded exponential backoff (2s-30s),
  retrying only on `ShareSystemBusyError` and failing immediately on
  any other error via `backoff.Permanent`. Mirrors the existing
  `mountSensitiveWithRetry` backoff pattern already in this file.
- **`pkg/dsm/service/share_volume.go`**: wrap `ShareNfsPrivilegeLoad` in
  `listSMBorNFSVolumes` with a shorter bounded backoff (1s-10s,
  deliberately short since it runs once per share in a loop over every
  share on the DSM), so a transient busy response no longer makes a
  share vanish from listings.

This is independent of #145 (a separate, unrelated Dockerfile fix) -
this PR contains only the NFS-retry commit.

## Testing

- `go build ./...` and `go vet ./...` clean across the whole repo.
- `gofmt` clean on all changed lines (pre-existing formatting drift
  elsewhere in these files was left untouched).
- Verified live against **DSM 7.3.2-86009 Update 4** on a **DS1517+**:
  created 24 NFS PVCs/pods concurrently against a 6-node cluster, which
  reproduced real DSM contention. Confirmed the new retry path firing
  via the log line:

  ```
  [INFO] [service/share_volume.go:233] Share NFS privilege system busy while loading [k8s-csi-pvc-...], retrying in 0.97 seconds.....
  ```

  All resulting volumes ended up with correct NFS export entries in
  `/etc/exports` (verified directly on the NAS) and were mountable from
  every node.
