### PR TITLE
Retry the DSM login instead of serving with no DSM registered

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,16 +5,20 @@
 package main
 
 import (
+	"fmt"
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
+	"github.com/cenkalti/backoff/v4"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
 	"github.com/SynologyOpenSource/synology-csi/pkg/driver"
 	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/common"
 	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/service"
+	"github.com/SynologyOpenSource/synology-csi/pkg/interfaces"
 	"github.com/SynologyOpenSource/synology-csi/pkg/logger"
 	"github.com/SynologyOpenSource/synology-csi/pkg/utils/hostexec"
 )
@@ -60,24 +64,52 @@ var rootCmd = &cobra.Command{
 	},
 }
 
+// loginDsms logs in to every configured DSM, retrying the ones that fail until
+// they all answer or the backoff gives up.
+//
+// The retry matters at boot. A DSM that is still starting - after a power cut the
+// NAS routinely needs several minutes longer than the nodes it serves - refuses the
+// login, and a single attempt leaves the driver running with an empty DSM set: the
+// pod stays Running and Ready, its probes pass, and every volume operation it is
+// handed fails until someone restarts it by hand.
+func loginDsms(dsmService interfaces.IDsmService, clients []common.ClientInfo, bo backoff.BackOff) error {
+	remaining := clients
+
+	login := func() error {
+		var failed []common.ClientInfo
+		for _, client := range remaining {
+			if err := dsmService.AddDsm(client); err != nil {
+				log.Warnf("Failed to add DSM: %s, error: %v", client.Host, err)
+				failed = append(failed, client)
+			}
+		}
+		remaining = failed
+
+		if len(remaining) > 0 {
+			return fmt.Errorf("%d of %d DSMs could not be logged in", len(remaining), len(clients))
+		}
+		return nil
+	}
+
+	notify := func(err error, duration time.Duration) {
+		log.Infof("%v, retrying in %3.2f seconds .....", err, float64(duration.Seconds()))
+	}
+
+	return backoff.RetryNotify(login, bo, notify)
+}
+
 func driverStart() error {
 	log.Infof("CSI Options = {%s, %s, %s}", csiNodeID, csiEndpoint, csiClientInfoPath)
 
 	dsmService := service.NewDsmService()
 
-	// 1. Login DSMs by given ClientInfo
+	// 1. Load the DSM ClientInfo
 	info, err := common.LoadConfig(csiClientInfoPath)
 	if err != nil {
 		log.Errorf("Failed to read config: %v", err)
 		return err
 	}
 
-	for _, client := range info.Clients {
-		err := dsmService.AddDsm(client)
-		if err != nil {
-			log.Errorf("Failed to add DSM: %s, error: %v", client.Host, err)
-		}
-	}
 	defer dsmService.RemoveAllDsms()
 
 	// 2. Create command executor
@@ -101,6 +133,23 @@ func driverStart() error {
 		return err
 	}
 	drv.Activate()
+
+	// 4. Log in to the DSMs, once the socket exists.
+	//
+	// Deliberately after Activate() and in the background: the node plugin's
+	// teardown path (NodeUnstageVolume, NodeUnpublishVolume) is plain unmounting
+	// and needs no DSM, so it must keep being served while the NAS is away -
+	// otherwise an unreachable NAS would also stop pods from terminating and
+	// block node drains.
+	loginBackoff := backoff.NewExponentialBackOff()
+	loginBackoff.InitialInterval = 1 * time.Second
+	loginBackoff.MaxInterval = 5 * time.Minute // a wrong password must not hammer DSM's auto-block
+	loginBackoff.MaxElapsedTime = 0            // keep retrying for as long as the driver runs
+	go func() {
+		if err := loginDsms(dsmService, info.Clients, loginBackoff); err != nil {
+			log.Errorf("Failed to add DSM, giving up. err: %v", err)
+		}
+	}()
 
 	c := make(chan os.Signal, 1)
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2021 Synology Inc.
+ */
+
+package main
+
+import (
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/cenkalti/backoff/v4"
+
+	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/common"
+	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/service"
+	"github.com/SynologyOpenSource/synology-csi/pkg/interfaces"
+)
+
+// fakeDsmService fails the login of every host in failures the given number of
+// times before letting it through. The embedded interface leaves the methods
+// loginDsms does not touch unimplemented - they panic if ever called.
+type fakeDsmService struct {
+	interfaces.IDsmService
+	failures map[string]int
+	added    map[string]bool
+}
+
+func newFakeDsmService(failures map[string]int) *fakeDsmService {
+	return &fakeDsmService{failures: failures, added: make(map[string]bool)}
+}
+
+func (f *fakeDsmService) AddDsm(client common.ClientInfo) error {
+	if f.added[client.Host] {
+		return nil
+	}
+	if f.failures[client.Host] > 0 {
+		f.failures[client.Host]--
+		return fmt.Errorf("dial tcp %s:5000: connect: connection refused", client.Host)
+	}
+	f.added[client.Host] = true
+	return nil
+}
+
+func (f *fakeDsmService) GetDsmsCount() int {
+	return len(f.added)
+}
+
+func testBackoff() backoff.BackOff {
+	return backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), 5)
+}
+
+func TestLoginDsmsRetriesUntilTheDsmAnswers(t *testing.T) {
+	svc := newFakeDsmService(map[string]int{"10.0.0.1": 3})
+	clients := []common.ClientInfo{{Host: "10.0.0.1"}}
+
+	if err := loginDsms(svc, clients, testBackoff()); err != nil {
+		t.Fatalf("expected the DSM to be added after its 3 failures, got: %v", err)
+	}
+	if svc.GetDsmsCount() != 1 {
+		t.Fatalf("expected 1 DSM added, got %d", svc.GetDsmsCount())
+	}
+}
+
+func TestLoginDsmsFailsWhenNoDsmAnswers(t *testing.T) {
+	svc := newFakeDsmService(map[string]int{"10.0.0.1": 99})
+	clients := []common.ClientInfo{{Host: "10.0.0.1"}}
+
+	if err := loginDsms(svc, clients, testBackoff()); err == nil {
+		t.Fatal("expected an error when no DSM could be logged in, got nil")
+	}
+	if svc.GetDsmsCount() != 0 {
+		t.Fatalf("expected 0 DSMs added, got %d", svc.GetDsmsCount())
+	}
+}
+
+func TestLoginDsmsKeepsTheDsmsThatAnswered(t *testing.T) {
+	svc := newFakeDsmService(map[string]int{"10.0.0.2": 99})
+	clients := []common.ClientInfo{{Host: "10.0.0.1"}, {Host: "10.0.0.2"}}
+
+	if err := loginDsms(svc, clients, testBackoff()); err == nil {
+		t.Fatal("expected an error naming the DSM that never answered, got nil")
+	}
+	// The reachable DSM stays registered and serving, whatever its peer does.
+	if svc.GetDsmsCount() != 1 {
+		t.Fatalf("expected 1 DSM added, got %d", svc.GetDsmsCount())
+	}
+	// The reachable DSM must not be re-added on every retry round.
+	if svc.failures["10.0.0.2"] != 99-6 {
+		t.Fatalf("expected 6 login attempts against the unreachable DSM, got %d", 99-svc.failures["10.0.0.2"])
+	}
+}
+
+func TestLoginDsmsWithNoClientsConfigured(t *testing.T) {
+	svc := newFakeDsmService(nil)
+
+	if err := loginDsms(svc, nil, testBackoff()); err != nil {
+		t.Fatalf("expected no error with no clients configured, got: %v", err)
+	}
+}
+
+// fakeDsm serves just enough of the DSM web API for AddDsm to succeed: the login
+// and the three SYNO.Core.System calls FillSystemInfo makes. The first failCount
+// requests are refused, standing in for a NAS that is still starting up.
+func fakeDsm(t *testing.T, failCount int32) common.ClientInfo {
+	t.Helper()
+
+	var seen int32
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if atomic.AddInt32(&seen, 1) <= failCount {
+			http.Error(w, "DSM is still starting", http.StatusServiceUnavailable)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"success":true,"data":{"sid":"fake-sid","hostname":"fake-nas","firmware_ver":"DSM 7.2","support_nvmeof":"no"}}`)
+	}))
+	t.Cleanup(srv.Close)
+
+	u, err := url.Parse(srv.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	port, err := strconv.Atoi(u.Port())
+	if err != nil {
+		t.Fatal(err)
+	}
+	return common.ClientInfo{Host: u.Hostname(), Port: port}
+}
+
+// End to end against a real DsmService: the login retries a NAS that is refusing
+// connections, and registers it once it answers, while the read paths a gRPC handler
+// would take are being exercised alongside it.
+//
+// The lock those reads depend on is covered by
+// service.TestDsmServiceReadsAreSafeWhileDsmsAreAdded - a single AddDsm write is too
+// narrow a target for -race to hit reliably.
+func TestLoginDsmsRegistersALateDsmWhileTheDriverIsServing(t *testing.T) {
+	dsmService := service.NewDsmService()
+	clients := []common.ClientInfo{fakeDsm(t, 20)}
+	bo := backoff.WithMaxRetries(backoff.NewConstantBackOff(time.Millisecond), 50)
+
+	done := make(chan error, 1)
+	go func() {
+		done <- loginDsms(dsmService, clients, bo)
+	}()
+
+	for {
+		select {
+		case err := <-done:
+			if err != nil {
+				t.Fatalf("expected the DSM to be added once it started answering, got: %v", err)
+			}
+			if dsmService.GetDsmsCount() != 1 {
+				t.Fatalf("expected 1 DSM added, got %d", dsmService.GetDsmsCount())
+			}
+			return
+		default:
+			// the read paths a gRPC handler would take
+			dsmService.GetDsmsCount()
+			dsmService.ListVolumes()
+			dsmService.ListAllSnapshots()
+		}
+	}
+}

--- a/pkg/dsm/service/dsm.go
+++ b/pkg/dsm/service/dsm.go
@@ -13,6 +13,7 @@ import (
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 	"strconv"
+	"sync"
 	"time"
 	"strings"
 	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/common"
@@ -22,7 +23,23 @@ import (
 )
 
 type DsmService struct {
-	dsms map[string]*webapi.DSM
+	// mutex guards dsms, which the background login retry in main.go writes to
+	// while the gRPC handlers are already reading it.
+	mutex sync.RWMutex
+	dsms  map[string]*webapi.DSM
+}
+
+// listDsms returns a snapshot of the registered DSMs, so that callers can iterate
+// without holding the lock across the DSM API calls they make on each one.
+func (service *DsmService) listDsms() []*webapi.DSM {
+	service.mutex.RLock()
+	defer service.mutex.RUnlock()
+
+	dsms := make([]*webapi.DSM, 0, len(service.dsms))
+	for _, dsm := range service.dsms {
+		dsms = append(dsms, dsm)
+	}
+	return dsms
 }
 
 func NewDsmService() *DsmService {
@@ -33,7 +50,11 @@ func NewDsmService() *DsmService {
 
 func (service *DsmService) AddDsm(client common.ClientInfo) error {
 	// TODO: use sn or other identifiers as key
-	if _, ok := service.dsms[client.Host]; ok {
+	service.mutex.RLock()
+	_, ok := service.dsms[client.Host]
+	service.mutex.RUnlock()
+
+	if ok {
 		log.Infof("Adding DSM [%s] already present.", client.Host)
 		return nil
 	}
@@ -53,13 +74,16 @@ func (service *DsmService) AddDsm(client common.ClientInfo) error {
 		return fmt.Errorf("Failed to get system info of DSM: [%s]. err: %v", dsm.Ip, err)
 	}
 
+	service.mutex.Lock()
 	service.dsms[dsm.Ip] = dsm
+	service.mutex.Unlock()
+
 	log.Infof("Add DSM [%s] hostname: %s.", dsm.Ip, dsm.Hostname)
 	return nil
 }
 
 func (service *DsmService) RemoveAllDsms() {
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		log.Infof("Going to logout DSM [%s]", dsm.Ip)
 
 		for i := 0; i < 3; i++ {
@@ -74,7 +98,10 @@ func (service *DsmService) RemoveAllDsms() {
 }
 
 func (service *DsmService) GetDsm(ip string) (*webapi.DSM, error) {
+	service.mutex.RLock()
 	dsm, ok := service.dsms[ip]
+	service.mutex.RUnlock()
+
 	if !ok {
 		return nil, fmt.Errorf("Requested dsm [%s] does not exist", ip)
 	}
@@ -82,13 +109,16 @@ func (service *DsmService) GetDsm(ip string) (*webapi.DSM, error) {
 }
 
 func (service *DsmService) GetDsmsCount() int {
+	service.mutex.RLock()
+	defer service.mutex.RUnlock()
+
 	return len(service.dsms)
 }
 
 func (service *DsmService) ListDsmVolumes(ip string) ([]webapi.VolInfo, error) {
 	var allVolInfos []webapi.VolInfo
 
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		if ip != "" && dsm.Ip != ip {
 			continue
 		}
@@ -554,7 +584,7 @@ func (service *DsmService) CreateVolume(spec *models.CreateK8sVolumeSpec) (*mode
 	}
 
 	/* Find appropriate dsm to create volume */
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		if spec.DsmIp != "" && spec.DsmIp != dsm.Ip {
 			continue
 		}
@@ -655,7 +685,7 @@ func (service *DsmService) DeleteVolume(volId string) error {
 }
 
 func (service *DsmService) listISCSIVolumes(dsmIp string) (infos []*models.K8sVolumeRespSpec) {
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		if dsmIp != "" && dsmIp != dsm.Ip {
 			continue
 		}
@@ -942,7 +972,7 @@ func (service *DsmService) listISCSISnapshotsByDsm(dsm *webapi.DSM) (infos []*mo
 func (service *DsmService) ListAllSnapshots() []*models.K8sSnapshotRespSpec {
 	var allInfos []*models.K8sSnapshotRespSpec
 
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		allInfos = append(allInfos, service.listISCSISnapshotsByDsm(dsm)...)
 		allInfos = append(allInfos, service.listSMBorNFSSnapshotsByDsm(dsm)...)
 		allInfos = append(allInfos, service.listNVMeSnapshotsByDsm(dsm)...)
@@ -1030,7 +1060,7 @@ func DsmSanSnapshotToK8sSnapshot(dsmIp string, info webapi.SnapshotInfo, protoco
 }
 
 func (service *DsmService) getISCSISnapshot(snapshotUuid string) *models.K8sSnapshotRespSpec {
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		snapshots := service.listISCSISnapshotsByDsm(dsm)
 		for _, snap := range snapshots {
 			if snap.Uuid == snapshotUuid {

--- a/pkg/dsm/service/dsm.go
+++ b/pkg/dsm/service/dsm.go
@@ -623,7 +623,7 @@ func (service *DsmService) DeleteVolume(volId string) error {
 			if  _, err := dsm.SubsystemGet(subsystem.Uuid); err != nil && errors.Is(err, utils.FailedToGetSubsystemError("")) {
 				return nil
 			}
-			log.Errorf("[%s] Failed to delete Subsystem(%d): %v", dsm.Ip, subsystem.Uuid, err)
+			log.Errorf("[%s] Failed to delete Subsystem(%s): %v", dsm.Ip, subsystem.Uuid, err)
 			return err
 		}
 	} else {

--- a/pkg/dsm/service/dsm_test.go
+++ b/pkg/dsm/service/dsm_test.go
@@ -1,0 +1,53 @@
+/*
+ * Copyright 2021 Synology Inc.
+ */
+
+package service
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/SynologyOpenSource/synology-csi/pkg/dsm/webapi"
+)
+
+// The DSM login retry runs in the background, so it writes to dsms while the gRPC
+// handlers are already reading it. Every reader has to go through the lock.
+//
+// Run with -race: on any of the paths the loop below calls, a `range service.dsms`
+// that should have been `range service.listDsms()` is reported here.
+//
+// The writes stand in for AddDsm's, which cannot be reached without a DSM to log in
+// to. The DSMs point at a closed port, so the webapi calls the readers make fail
+// immediately without reaching the network.
+func TestDsmServiceReadsAreSafeWhileDsmsAreAdded(t *testing.T) {
+	service := NewDsmService()
+
+	// Keep only a few DSMs registered - the readers below dial every one of them -
+	// but keep writing for as long as the readers run.
+	stop := make(chan struct{})
+	written := make(chan struct{})
+	go func() {
+		defer close(written)
+		for i := 0; ; i++ {
+			select {
+			case <-stop:
+				return
+			default:
+			}
+			service.mutex.Lock()
+			service.dsms[strconv.Itoa(i%4)] = &webapi.DSM{Ip: "127.0.0.1", Port: 1}
+			service.mutex.Unlock()
+		}
+	}()
+
+	for i := 0; i < 100; i++ {
+		service.GetDsmsCount()
+		service.listDsms()
+		service.ListVolumes()
+		service.ListAllSnapshots()
+	}
+
+	close(stop)
+	<-written
+}

--- a/pkg/dsm/service/namespace_volume.go
+++ b/pkg/dsm/service/namespace_volume.go
@@ -193,7 +193,7 @@ func (service *DsmService) createNVMeVolumeByDsm(dsm *webapi.DSM, spec *models.C
 }
 
 func (service *DsmService) listNVMeVolumes(dsmIp string) (infos []*models.K8sVolumeRespSpec) {
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		if dsmIp != "" && dsmIp != dsm.Ip {
 			continue
 		}

--- a/pkg/dsm/service/share_volume.go
+++ b/pkg/dsm/service/share_volume.go
@@ -185,7 +185,7 @@ func (service *DsmService) createSMBorNFSVolumeByDsm(dsm *webapi.DSM, spec *mode
 }
 
 func (service *DsmService) listSMBorNFSVolumes(dsmIp string) (infos []*models.K8sVolumeRespSpec) {
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		if dsmIp != "" && dsmIp != dsm.Ip {
 			continue
 		}
@@ -238,7 +238,7 @@ func (service *DsmService) listSMBorNFSSnapshotsByDsm(dsm *webapi.DSM) (infos []
 }
 
 func (service *DsmService) getSMBorNFSSnapshot(snapshotUuid string) *models.K8sSnapshotRespSpec {
-	for _, dsm := range service.dsms {
+	for _, dsm := range service.listDsms() {
 		snapshots := service.listSMBorNFSSnapshotsByDsm(dsm)
 		for _, snap := range snapshots {
 			if snap.Uuid == snapshotUuid {


### PR DESCRIPTION
## The problem

`driverStart()` logs in to each configured DSM exactly once. If that login fails, the error
is logged and discarded, and the driver goes on to serve gRPC with an **empty DSM set**:

```go
for _, client := range info.Clients {
    err := dsmService.AddDsm(client)
    if err != nil {
        log.Errorf("Failed to add DSM: %s, error: %v", client.Host, err)  // and that is all
    }
}
```

This is easy to hit after a power cut: the NAS needs minutes to serve its API, the
Kubernetes nodes are up in under one. In my case all four CSI pods failed their login
**three seconds after starting** and never tried again:

```
13:15:19Z  synology-csi-controller-0 / node-wdf9g
  Failed to add DSM: 192.168.10.10 ... dial tcp 192.168.10.10:5000: connect: no route to host
13:44:13Z  synology-csi-node-d479x
  Failed to add DSM: 192.168.10.10 ... dial tcp 192.168.10.10:5000: connect: connection refused
```

Two error strings 29 minutes apart — the NAS wasn't on the network yet, then it was on the
network but DSM wasn't listening. The nodes won the boot race twice, at two different stages.

The nasty part is that nothing surfaces the resulting state. All four pods report `Running`,
`2/2` and `4/4`, their containers are healthy and `kubectl get pods -n storage` looks
perfect — while every volume operation they receive fails:

```
forgejo  FailedMount  ... Failed to set NFS privilege rule, source: //192.168.10.10/k8s-csi-pvc-…,
                          err: Failed to get DSM[192.168.10.10]
openbao  FailedMount  ... rpc error: code = NotFound desc = Volume[0090ee6b-…] is not found
```

The iSCSI error is especially misleading. `Volume[...] is not found` reads like a missing
LUN, which after a power cut on a single-bay NAS is alarming. It isn't: the driver resolves
a volume by listing every target through the DSM API, and with no DSM registered that list
is empty, so a perfectly healthy LUN reports as absent.

Only restarting the pods re-attempts the login. It has now cost me two outages.

## The change

Retry the clients that failed, with exponential backoff, until they all answer, using the
`cenkalti/backoff/v4` already used in `waitCloneFinished` and `nodeserver.go`. Mid-life
session loss is already recovered by the re-login in `sendRequest()` (error codes
105/106/119) — this only closes the startup gap.

Two decisions worth flagging for review:

**The retry runs in a goroutine started *after* `drv.Activate()`.** My first version blocked
before it and that was wrong. `Activate()` is what creates the CSI socket, and the node
plugin's teardown path — `NodeUnstageVolume`, `NodeUnpublishVolume` — is plain unmounting
that touches no DSM. Withholding the socket until the NAS answers would turn an unreachable
NAS into pods that cannot terminate and nodes that cannot be drained, which is worse than
the bug being fixed. For the same reason it retries **forever** rather than giving up and
exiting: giving up just returns the driver to serving blind.

**`DsmService.dsms` therefore needed a lock.** Moving `AddDsm` after `Activate()` puts its
map write alongside the gRPC handlers reading it. The map is now guarded by an `RWMutex`,
with a `listDsms()` snapshot for the ten call sites that iterate it while making DSM API
calls (holding the lock across those would serialise every request).

`MaxInterval` is 5 minutes so that a genuinely wrong password doesn't hammer DSM's
auto-block forever; the first ~9 minutes ramp from 1s, so the boot-race case recovers
quickly.

No new dependency, no new flag, no manifest or chart change.

## Tests

`main_test.go` covers the retry (fake `IDsmService`) and one end-to-end case against a real
`DsmService` and an `httptest` DSM that refuses the first 20 requests.

`pkg/dsm/service/dsm_test.go` covers the locking: it hammers the reader paths while DSMs are
being added, and under `-race` it reports any `range service.dsms` that should have been
`range service.listDsms()`. Verified by reverting a call site — 14 races reported; 0 with the
fix in place.

```
go vet . ./pkg/dsm/service/     # clean
make build                      # OK
go test -race -count=3 . ./pkg/dsm/service/ ./pkg/utils/hostexec/   # all ok
```

`test/sanity` still needs a live NAS (`config/client-info.yml`) and is unchanged.

## The first commit

`Fix the format verb for the Subsystem UUID delete error` is a one-character change
(`%d` → `%s` on a string). It's the only `go vet` diagnostic in `pkg/dsm/service`, and it
makes the package fail to build under `go test`, so the new test there can't run without it.
Happy to split it out if you'd rather take it separately.

## Related

Not a fix for #65 — that one is a credentials/config problem, not a boot race. But it lands
in the same silent state (`Couldn't find any host available to create Volume` is what
`CreateVolume` returns when `dsms` is empty), and the reporter spent "many hours" on it. With
this change a bad password produces a repeating warning naming the host and the error, rather
than a single line three seconds into startup.

## Noted but not changed

`sendRequestWithoutConnectionCheck` builds an `http.Client{}` with no `Timeout`. Against a
blackholed IP (firewall DROP rather than RST) a request can hang far longer than any
backoff deadline. Out of scope here, but worth a look.
